### PR TITLE
Add support for flambda2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,14 @@ AS_IF([test `printf "$OCAMLVERSION\n3.12.0" | sort | head -n1` = 3.12.0],
     [[`echo 'Sys.os_type;;' | $OCAML | sed -n 's/^\# - : string = "\(.*\)"$/\1/p'`]])])
 AC_MSG_RESULT([$target_os_type])
 
+AC_MSG_CHECKING([for flambda2])
+
+AC_SUBST([OCAML_FLAMBDA2],
+    [`$OCAMLBEST -config | sed -n 's/^flambda2: \(.*\)$/\1/p' | sed 's/\r//'`])
+AS_IF([test "x$OCAML_FLAMBDA2" = "x"], AC_SUBST([OCAML_FLAMBDA2], [[false]]))
+
+AC_MSG_RESULT([$OCAML_FLAMBDA2])
+
 AC_ARG_ENABLE([magic],
             [AS_HELP_STRING([--enable-magic],
               [[use Obj.magic in redefinitions when possible (default)]]),
@@ -165,6 +173,10 @@ AS_IF([test "x$target_os_type" = "xCygwin"],
 AS_IF([test "x$target_os_type" = "xUnix"],
   [AC_WITH_BLOCK([UNIX])],
   [AC_WITHOUT_BLOCK([UNIX])])
+
+AS_IF([test "x$OCAML_FLAMBDA2" = "xtrue"],
+  [AC_WITH_BLOCK([FLAMBDA2])],
+  [AC_WITHOUT_BLOCK([FLAMBDA2])])
 
 AM_CONDITIONAL(OCAML_SUPPORTS_BYTECODE, [test "x$OCAMLC" != "x"])
 

--- a/stdcompat__pervasives_s.mli.in
+++ b/stdcompat__pervasives_s.mli.in
@@ -1033,11 +1033,20 @@ module type S = sig
   @since 3.07.0: external float_of_string : string -> float = "float_of_string"
    *)
   
+  @BEGIN_WITH_FLAMBDA2@
+  external fst : ('a * 'b) -> 'a = "%field0_immut"
+  (** Alias for {!Pervasives.fst} *)
+  
+  external snd : ('a * 'b) -> 'b = "%field1_immut"
+  (** Alias for {!Pervasives.snd} *)
+  @END_WITH_FLAMBDA2@
+  @BEGIN_WITHOUT_FLAMBDA2@
   external fst : ('a * 'b) -> 'a = "%field0"
   (** Alias for {!Pervasives.fst} *)
   
   external snd : ('a * 'b) -> 'b = "%field1"
   (** Alias for {!Pervasives.snd} *)
+  @END_WITHOUT_FLAMBDA2@
   
   val (@) : 'a list -> 'a list -> 'a list
   (** Alias for {!Pervasives.@} *)


### PR DESCRIPTION
The second version of flambda (called flambda2), which is currently under developpement, requires some small changes to the interface of the stdlib. Currently the only change is that the primitives used for `fst` and `snd` are changed to use immutable reads (instead of the current primitives which are treated as mutable reads).

This PR adds support for flambda2 by adding blocks that are conditional on the presence of flambda2 (similar as the blocks conditional on the target platform), and uses these blocks to update the interface of `Pervasives` to make it compatible with flambda2.

I'm not sure the code I wrote in `configure.ac` for flambda2 detection is idiomatic or not, so don't hesitate to tell me if there are better ways to do that in autoconf (the main problem I have is that while the flambda2 version of the compiler has a `flambda2 : true` line in `ocamlc -config`, other versions of the compiler do not).