### PR TITLE
Update `dune` port

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,3 @@
-ACLOCAL_AMFLAGS = -I m4
-
 mypkgdir=$(pkglibdir)
 
 EXTRA_DIST= stdcompat.opam dune stdcompat.ml stdcompat__native.ml_byte \

--- a/dune
+++ b/dune
@@ -35,6 +35,7 @@
  (deps
   META.in
   Makefile.am
+  VERSION
   stdcompat.ml.in
   stdcompat.mli.in
   stdcompat__arg.ml.in

--- a/dune
+++ b/dune
@@ -26,6 +26,11 @@
  (action (run cp %{source} %{targets})))
 
 (rule
+ (targets stdcompat__init.ml.in)
+ (deps (:source stdcompat__init.mli.in))
+ (action (run cp %{source} %{targets})))
+
+(rule
  (target configure)
  (deps
   META.in

--- a/dune
+++ b/dune
@@ -3,6 +3,9 @@
  (public_name stdcompat)
  (flags (:standard -nolabels))
  (install_c_headers stdcompat)
+ (foreign_stubs
+  (language c)
+  (names stdcompat__stubs))
  (modules
    stdcompat__arg
    stdcompat__arg_s

--- a/dune
+++ b/dune
@@ -1,19 +1,99 @@
 (library
  (name stdcompat)
  (public_name stdcompat)
- (modules stdcompat__native stdcompat__init stdcompat__root stdcompat__seq
+ (modules
+   stdcompat__arg
+   stdcompat__arg_s
+   stdcompat__array
+   stdcompat__arrayLabels
+   stdcompat__arrayLabels_s
+   stdcompat__array_s
+   stdcompat__atomic
+   stdcompat__atomic_s
+   stdcompat__bool
+   stdcompat__bool_s
+   stdcompat__buffer
+   stdcompat__buffer_s
+   stdcompat__bytes
+   stdcompat__bytesLabels
+   stdcompat__bytesLabels_s
+   stdcompat__bytes_s
+   stdcompat__char
+   stdcompat__char_s
+   stdcompat__digest
+   stdcompat__digest_s
+   stdcompat__either
+   stdcompat__either_s
+   stdcompat__ephemeron
+   stdcompat__ephemeron_s
+   stdcompat__filename
+   stdcompat__filename_s
+   stdcompat__float
+   stdcompat__float_s
+   stdcompat__format
+   stdcompat__format_s
+   stdcompat__fun
+   stdcompat__fun_s
+   stdcompat__hashtbl
+   stdcompat__hashtbl_ext
+   stdcompat__hashtbl_s
+   stdcompat__init
+   stdcompat__int
+   stdcompat__int32
+   stdcompat__int32_s
+   stdcompat__int64
+   stdcompat__int64_s
+   stdcompat__int_s
+   stdcompat__lazy
+   stdcompat__lazy_s
+   stdcompat__lexing
+   stdcompat__lexing_s
+   stdcompat__list
+   stdcompat__listLabels
+   stdcompat__listLabels_s
+   stdcompat__list_s
+   stdcompat__map
+   stdcompat__map_s
+   stdcompat__moreLabels
+   stdcompat__moreLabels_s
+   stdcompat__native
+   stdcompat__nativeint
+   stdcompat__nativeint_s
+   stdcompat__option
+   stdcompat__option_s
+   stdcompat__pervasives
+   stdcompat__pervasives_s
+   stdcompat__printexc
+   stdcompat__printexc_s
+   stdcompat__printf
+   stdcompat__printf_s
+   stdcompat__queue
+   stdcompat__queue_s
+   stdcompat__result
+   stdcompat__result_s
+   stdcompat__root
+   stdcompat__seq
+   stdcompat__seq_s
+   stdcompat__set
+   stdcompat__set_s
+   stdcompat__stack
+   stdcompat__stack_s
+   stdcompat__stdlib
+   stdcompat__stdlib_s
+   stdcompat__stream
+   stdcompat__stream_s
+   stdcompat__string
+   stdcompat__stringLabels
+   stdcompat__stringLabels_s
+   stdcompat__string_s
+   stdcompat__sys
+   stdcompat__sys_s
    stdcompat__tools
-   stdcompat__pervasives stdcompat__arg stdcompat__lazy
-   stdcompat__char stdcompat__uchar stdcompat__buffer
-   stdcompat__string stdcompat__stringLabels stdcompat__bytes
-   stdcompat__bytesLabels stdcompat__list stdcompat__listLabels
-   stdcompat__stack stdcompat__hashtbl_ext stdcompat__hashtbl stdcompat__set
-   stdcompat__map stdcompat__weak stdcompat__sys
-   stdcompat__stream stdcompat__digest stdcompat__nativeint
-   stdcompat__int stdcompat__int64 stdcompat__int32 stdcompat__filename
-   stdcompat__array stdcompat__arrayLabels
-   stdcompat__float stdcompat__queue stdcompat__ephemeron
-   stdcompat__moreLabels stdcompat))
+   stdcompat__uchar
+   stdcompat__uchar_s
+   stdcompat__weak
+   stdcompat__weak_s
+   stdcompat))
 
 (executable
  (name stdcompat_tests)
@@ -192,79 +272,186 @@
   stdcompat.ml
   stdcompat.mli
   stdcompat_tests.ml
-  stdcompat__init.mli
-  stdcompat__hashtbl_ext.mli
-  stdcompat__root.mli
-  stdcompat__tools.mli
-  stdcompat__pervasives.mli
-  stdcompat__arg.mli
-  stdcompat__array.mli
-  stdcompat__arrayLabels.mli
-  stdcompat__buffer.mli
-  stdcompat__bytes.mli
-  stdcompat__bytesLabels.mli
-  stdcompat__char.mli
-  stdcompat__digest.mli
-  stdcompat__ephemeron.mli
-  stdcompat__filename.mli
-  stdcompat__float.mli
-  stdcompat__hashtbl.mli
-  stdcompat__int.mli
-  stdcompat__int32.mli
-  stdcompat__int64.mli
-  stdcompat__lazy.mli
-  stdcompat__lexing.mli
-  stdcompat__list.mli
-  stdcompat__listLabels.mli
-  stdcompat__map.mli
-  stdcompat__moreLabels.mli
-  stdcompat__nativeint.mli
-  stdcompat__queue.mli
-  stdcompat__seq.mli
-  stdcompat__set.mli
-  stdcompat__stack.mli
-  stdcompat__stream.mli
-  stdcompat__string.mli
-  stdcompat__stringLabels.mli
-  stdcompat__sys.mli
-  stdcompat__uchar.mli
-  stdcompat__weak.mli
-  stdcompat__init.ml
-  stdcompat__hashtbl_ext.ml
-  stdcompat__root.ml
-  stdcompat__tools.ml
-  stdcompat__pervasives.ml
   stdcompat__arg.ml
+  stdcompat__arg.mli
+  stdcompat__arg_s.ml
+  stdcompat__arg_s.mli
   stdcompat__array.ml
+  stdcompat__array.mli
   stdcompat__arrayLabels.ml
+  stdcompat__arrayLabels.mli
+  stdcompat__arrayLabels_s.ml
+  stdcompat__arrayLabels_s.mli
+  stdcompat__array_s.ml
+  stdcompat__array_s.mli
+  stdcompat__atomic.ml
+  stdcompat__atomic.mli
+  stdcompat__atomic_s.ml
+  stdcompat__atomic_s.mli
+  stdcompat__bool.ml
+  stdcompat__bool.mli
+  stdcompat__bool_s.ml
+  stdcompat__bool_s.mli
   stdcompat__buffer.ml
+  stdcompat__buffer.mli
+  stdcompat__buffer_s.ml
+  stdcompat__buffer_s.mli
   stdcompat__bytes.ml
+  stdcompat__bytes.mli
   stdcompat__bytesLabels.ml
+  stdcompat__bytesLabels.mli
+  stdcompat__bytesLabels_s.ml
+  stdcompat__bytesLabels_s.mli
+  stdcompat__bytes_s.ml
+  stdcompat__bytes_s.mli
   stdcompat__char.ml
+  stdcompat__char.mli
+  stdcompat__char_s.ml
+  stdcompat__char_s.mli
   stdcompat__digest.ml
+  stdcompat__digest.mli
+  stdcompat__digest_s.ml
+  stdcompat__digest_s.mli
+  stdcompat__either.ml
+  stdcompat__either.mli
+  stdcompat__either_s.ml
+  stdcompat__either_s.mli
   stdcompat__ephemeron.ml
+  stdcompat__ephemeron.mli
+  stdcompat__ephemeron_s.ml
+  stdcompat__ephemeron_s.mli
   stdcompat__filename.ml
+  stdcompat__filename.mli
+  stdcompat__filename_s.ml
+  stdcompat__filename_s.mli
   stdcompat__float.ml
+  stdcompat__float.mli
+  stdcompat__float_s.ml
+  stdcompat__float_s.mli
+  stdcompat__format.ml
+  stdcompat__format.mli
+  stdcompat__format_s.ml
+  stdcompat__format_s.mli
+  stdcompat__fun.ml
+  stdcompat__fun.mli
+  stdcompat__fun_s.ml
+  stdcompat__fun_s.mli
   stdcompat__hashtbl.ml
+  stdcompat__hashtbl.mli
+  stdcompat__hashtbl_ext.ml
+  stdcompat__hashtbl_ext.mli
+  stdcompat__hashtbl_s.ml
+  stdcompat__hashtbl_s.mli
+  stdcompat__init.ml
+  stdcompat__init.mli
   stdcompat__int.ml
+  stdcompat__int.mli
   stdcompat__int32.ml
+  stdcompat__int32.mli
+  stdcompat__int32_s.ml
+  stdcompat__int32_s.mli
   stdcompat__int64.ml
+  stdcompat__int64.mli
+  stdcompat__int64_s.ml
+  stdcompat__int64_s.mli
+  stdcompat__int_s.ml
+  stdcompat__int_s.mli
   stdcompat__lazy.ml
+  stdcompat__lazy.mli
+  stdcompat__lazy_s.ml
+  stdcompat__lazy_s.mli
+  stdcompat__lexing.ml
+  stdcompat__lexing.mli
+  stdcompat__lexing_s.ml
+  stdcompat__lexing_s.mli
   stdcompat__list.ml
+  stdcompat__list.mli
   stdcompat__listLabels.ml
+  stdcompat__listLabels.mli
+  stdcompat__listLabels_s.ml
+  stdcompat__listLabels_s.mli
+  stdcompat__list_s.ml
+  stdcompat__list_s.mli
   stdcompat__map.ml
+  stdcompat__map.mli
+  stdcompat__map_s.ml
+  stdcompat__map_s.mli
   stdcompat__moreLabels.ml
+  stdcompat__moreLabels.mli
+  stdcompat__moreLabels_s.ml
+  stdcompat__moreLabels_s.mli
   stdcompat__nativeint.ml
+  stdcompat__nativeint.mli
+  stdcompat__nativeint_s.ml
+  stdcompat__nativeint_s.mli
+  stdcompat__option.ml
+  stdcompat__option.mli
+  stdcompat__option_s.ml
+  stdcompat__option_s.mli
+  stdcompat__pervasives.ml
+  stdcompat__pervasives.mli
+  stdcompat__pervasives_s.ml
+  stdcompat__pervasives_s.mli
+  stdcompat__printexc.ml
+  stdcompat__printexc.mli
+  stdcompat__printexc_s.ml
+  stdcompat__printexc_s.mli
+  stdcompat__printf.ml
+  stdcompat__printf.mli
+  stdcompat__printf_s.ml
+  stdcompat__printf_s.mli
   stdcompat__queue.ml
+  stdcompat__queue.mli
+  stdcompat__queue_s.ml
+  stdcompat__queue_s.mli
+  stdcompat__result.ml
+  stdcompat__result.mli
+  stdcompat__result_s.ml
+  stdcompat__result_s.mli
+  stdcompat__root.ml
+  stdcompat__root.mli
   stdcompat__seq.ml
+  stdcompat__seq.mli
+  stdcompat__seq_s.ml
+  stdcompat__seq_s.mli
   stdcompat__set.ml
+  stdcompat__set.mli
+  stdcompat__set_s.ml
+  stdcompat__set_s.mli
   stdcompat__stack.ml
+  stdcompat__stack.mli
+  stdcompat__stack_s.ml
+  stdcompat__stack_s.mli
+  stdcompat__stdlib.ml
+  stdcompat__stdlib.mli
+  stdcompat__stdlib_s.ml
+  stdcompat__stdlib_s.mli
   stdcompat__stream.ml
+  stdcompat__stream.mli
+  stdcompat__stream_s.ml
+  stdcompat__stream_s.mli
   stdcompat__string.ml
+  stdcompat__string.mli
   stdcompat__stringLabels.ml
+  stdcompat__stringLabels.mli
+  stdcompat__stringLabels_s.ml
+  stdcompat__stringLabels_s.mli
+  stdcompat__string_s.ml
+  stdcompat__string_s.mli
   stdcompat__stubs.c
   stdcompat__sys.ml
+  stdcompat__sys.mli
+  stdcompat__sys_s.ml
+  stdcompat__sys_s.mli
+  stdcompat__tools.ml
+  stdcompat__tools.mli
   stdcompat__uchar.ml
-  stdcompat__weak.ml)
+  stdcompat__uchar.mli
+  stdcompat__uchar_s.ml
+  stdcompat__uchar_s.mli
+  stdcompat__weak.ml
+  stdcompat__weak.mli
+  stdcompat__weak_s.ml
+  stdcompat__weak_s.mli)
   (deps (:configure configure))
   (action (run %{configure})))

--- a/dune
+++ b/dune
@@ -38,6 +38,8 @@
    stdcompat__hashtbl
    stdcompat__hashtbl_ext
    stdcompat__hashtbl_s
+   stdcompat__in_channel
+   stdcompat__in_channel_s
    stdcompat__init
    stdcompat__int
    stdcompat__int32
@@ -62,6 +64,8 @@
    stdcompat__nativeint_s
    stdcompat__option
    stdcompat__option_s
+   stdcompat__out_channel
+   stdcompat__out_channel_s
    stdcompat__pervasives
    stdcompat__pervasives_s
    stdcompat__printexc
@@ -70,6 +74,8 @@
    stdcompat__printf_s
    stdcompat__queue
    stdcompat__queue_s
+   stdcompat__random
+   stdcompat__random_s
    stdcompat__result
    stdcompat__result_s
    stdcompat__root
@@ -92,6 +98,8 @@
    stdcompat__tools
    stdcompat__uchar
    stdcompat__uchar_s
+   stdcompat__unit
+   stdcompat__unit_s
    stdcompat__weak
    stdcompat__weak_s
    stdcompat))
@@ -173,6 +181,9 @@
   stdcompat__hashtbl_ext.ml.in
   stdcompat__hashtbl_ext.mli.in
   stdcompat__hashtbl_s.mli.in
+  stdcompat__in_channel.ml.in
+  stdcompat__in_channel.mli.in
+  stdcompat__in_channel_s.mli.in
   stdcompat__init.ml.in
   stdcompat__init.mli.in
   stdcompat__int.ml.in
@@ -210,6 +221,9 @@
   stdcompat__option.ml.in
   stdcompat__option.mli.in
   stdcompat__option_s.mli.in
+  stdcompat__out_channel.ml.in
+  stdcompat__out_channel.mli.in
+  stdcompat__out_channel_s.mli.in
   stdcompat__pervasives.ml.in
   stdcompat__pervasives.mli.in
   stdcompat__pervasives_s.mli.in
@@ -222,6 +236,9 @@
   stdcompat__queue.ml.in
   stdcompat__queue.mli.in
   stdcompat__queue_s.mli.in
+  stdcompat__random.ml.in
+  stdcompat__random.mli.in
+  stdcompat__random_s.mli.in
   stdcompat__result.ml.in
   stdcompat__result.mli.in
   stdcompat__result_s.mli.in
@@ -257,6 +274,9 @@
   stdcompat__uchar.ml.in
   stdcompat__uchar.mli.in
   stdcompat__uchar_s.mli.in
+  stdcompat__unit.ml.in
+  stdcompat__unit.mli.in
+  stdcompat__unit_s.mli.in
   stdcompat__weak.ml.in
   stdcompat__weak.mli.in
   stdcompat__weak_s.mli.in
@@ -343,6 +363,10 @@
   stdcompat__hashtbl_ext.mli
   stdcompat__hashtbl_s.ml
   stdcompat__hashtbl_s.mli
+  stdcompat__in_channel.ml
+  stdcompat__in_channel.mli
+  stdcompat__in_channel_s.ml
+  stdcompat__in_channel_s.mli
   stdcompat__init.ml
   stdcompat__init.mli
   stdcompat__int.ml
@@ -389,6 +413,10 @@
   stdcompat__option.mli
   stdcompat__option_s.ml
   stdcompat__option_s.mli
+  stdcompat__out_channel.ml
+  stdcompat__out_channel.mli
+  stdcompat__out_channel_s.ml
+  stdcompat__out_channel_s.mli
   stdcompat__pervasives.ml
   stdcompat__pervasives.mli
   stdcompat__pervasives_s.ml
@@ -405,6 +433,10 @@
   stdcompat__queue.mli
   stdcompat__queue_s.ml
   stdcompat__queue_s.mli
+  stdcompat__random.ml
+  stdcompat__random.mli
+  stdcompat__random_s.ml
+  stdcompat__random_s.mli
   stdcompat__result.ml
   stdcompat__result.mli
   stdcompat__result_s.ml
@@ -450,6 +482,10 @@
   stdcompat__uchar.mli
   stdcompat__uchar_s.ml
   stdcompat__uchar_s.mli
+  stdcompat__unit.ml
+  stdcompat__unit.mli
+  stdcompat__unit_s.ml
+  stdcompat__unit_s.mli
   stdcompat__weak.ml
   stdcompat__weak.mli
   stdcompat__weak_s.ml

--- a/dune
+++ b/dune
@@ -13,7 +13,7 @@
    stdcompat__int stdcompat__int64 stdcompat__int32 stdcompat__filename
    stdcompat__array stdcompat__arrayLabels
    stdcompat__float stdcompat__queue stdcompat__ephemeron
-   stdcompat__spacetime stdcompat__moreLabels stdcompat))
+   stdcompat__moreLabels stdcompat))
 
 (executable
  (name stdcompat_tests)
@@ -139,9 +139,6 @@
   stdcompat__set.ml.in
   stdcompat__set.mli.in
   stdcompat__set_s.mli.in
-  stdcompat__spacetime.ml.in
-  stdcompat__spacetime.mli.in
-  stdcompat__spacetime_s.mli.in
   stdcompat__stack.ml.in
   stdcompat__stack.mli.in
   stdcompat__stack_s.mli.in
@@ -212,7 +209,6 @@
   stdcompat__queue.mli
   stdcompat__seq.mli
   stdcompat__set.mli
-  stdcompat__spacetime.mli
   stdcompat__stack.mli
   stdcompat__stream.mli
   stdcompat__string.mli
@@ -249,7 +245,6 @@
   stdcompat__queue.ml
   stdcompat__seq.ml
   stdcompat__set.ml
-  stdcompat__spacetime.ml
   stdcompat__stack.ml
   stdcompat__stream.ml
   stdcompat__string.ml

--- a/dune
+++ b/dune
@@ -36,6 +36,7 @@
   META.in
   Makefile.am
   VERSION
+  stdcompat.h.in
   stdcompat.ml.in
   stdcompat.mli.in
   stdcompat__arg.ml.in
@@ -47,6 +48,9 @@
   stdcompat__arrayLabels.mli.in
   stdcompat__arrayLabels_s.mli.in
   stdcompat__array_s.mli.in
+  stdcompat__atomic.ml.in
+  stdcompat__atomic.mli.in
+  stdcompat__atomic_s.mli.in
   stdcompat__bool.ml.in
   stdcompat__bool.mli.in
   stdcompat__bool_s.mli.in
@@ -65,6 +69,9 @@
   stdcompat__digest.ml.in
   stdcompat__digest.mli.in
   stdcompat__digest_s.mli.in
+  stdcompat__either.ml.in
+  stdcompat__either.mli.in
+  stdcompat__either_s.mli.in
   stdcompat__ephemeron.ml.in
   stdcompat__ephemeron.mli.in
   stdcompat__ephemeron_s.mli.in

--- a/dune
+++ b/dune
@@ -1,6 +1,7 @@
 (library
  (name stdcompat)
  (public_name stdcompat)
+ (flags (:standard -nolabels))
  (modules
    stdcompat__arg
    stdcompat__arg_s

--- a/dune
+++ b/dune
@@ -110,14 +110,14 @@
  (libraries stdcompat))
 
 (rule
- (targets stdcompat__native.ml)
- (deps (:source stdcompat__native.ml_native))
- (action (run cp %{source} %{targets})))
+ (target stdcompat__native.ml)
+ (deps stdcompat__native.ml_native)
+ (action (copy %{deps} %{target})))
 
 (rule
- (targets stdcompat__init.ml.in)
- (deps (:source stdcompat__init.mli.in))
- (action (run cp %{source} %{targets})))
+ (target stdcompat__init.ml.in)
+ (deps stdcompat__init.mli.in)
+ (action (copy %{deps} %{target})))
 
 (rule
  (target configure)

--- a/dune
+++ b/dune
@@ -2,6 +2,7 @@
  (name stdcompat)
  (public_name stdcompat)
  (flags (:standard -nolabels))
+ (install_c_headers stdcompat)
  (modules
    stdcompat__arg
    stdcompat__arg_s
@@ -288,6 +289,7 @@
  (targets
   META
   Makefile
+  stdcompat.h
   stdcompat__native.ml_byte
   stdcompat__native.ml_native
   stdcompat.ml

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.11)
+(lang dune 2.0)
 (name stdcompat)

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
 (lang dune 1.11)
+(name stdcompat)


### PR DESCRIPTION
I need to use the dune feature of building the code in a subfolder. So I was happy to see that the project has a `dune` file, but unfortunately it turns out that this dune file doesn't build the code successfully anymore due to changes in the project that haven't been reflected in the `dune` file.

As such I started porting and decided to upstream the relevant changes. Maybe it would be possible to adopt this as main build, that would prevent the dune files from bitrotting.