### PR TITLE
Use dune as build system in the OPAM file

### DIFF
--- a/stdcompat.opam
+++ b/stdcompat.opam
@@ -9,13 +9,13 @@ homepage: "https://github.com/thierry-martinez/stdcompat"
 bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
 depends: [
   "ocaml" {>= "3.07"}
+  "dune" {>= "2.0"}
 ]
 depopts: [ "result" "seq" "uchar" "ocamlfind" ]
 build: [
-  [make "-f" "Makefile.bootstrap" "-j" jobs]
-  ["./configure" "--prefix=%{prefix}%"]
-  [make "all" "test" {with-test}]
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-install: [make "install"]
 dev-repo: "git+https://github.com/thierry-martinez/stdcompat.git"
 version: "18"


### PR DESCRIPTION
Thanks Thierry for accepting and improving the dune port, your improvements to the targets are very sinsible. I've been contemplating how to make the build a bit simpler and not require giant `dune` files. One option could be to replace autotools (which, if I see correctly is mainly used for the compiler version switches, something that `cppo` should be able to do, without requiring users to have autotools installed) and then just call `cppo` directly.

For now this PR changes the build to use `dune` instead of the autotools based system. The advantage is that it allows to use the dune cache and be used with `opam-monorepo` out of the box.

Let me know what your thoughts are!