### PR TITLE
Do not wrap stdcompat modules (as they are already prefixed with Stdcompat__)

### DIFF
--- a/dune
+++ b/dune
@@ -1,6 +1,7 @@
 (library
  (name stdcompat)
  (public_name stdcompat)
+ (wrapped false)
  (flags (:standard -nolabels -w -3))
  (install_c_headers stdcompat)
  (foreign_stubs


### PR DESCRIPTION
Otherwise it creates accessible modules as `Stdcompat__stdcompat__<module>` which seems unnecessarily long.
This would allow compatibility with the old style as well. e.g. `Stdcompat__format` found in `override.0.4.0`