### PR TITLE
Find all tools with AC_CHECK_TOOL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,29 +61,24 @@ AS_IF([test "$OCAML_RELEASE_EXTRA_PREFIX_CHAR" = "~"],
       [AC_SUBST([OCAML_DEVELOPMENT_VERSION], [[false]])])],
     [AC_SUBST([OCAML_DEVELOPMENT_VERSION], [[false]])])])
 
+AC_CHECK_TOOL([OCAMLOPT], [ocamlopt.opt], [])
+AS_IF([test "x$OCAMLOPT" = "x"],
+  [AC_CHECK_TOOL([OCAMLOPT], [ocamlopt], [])])
+AC_CHECK_TOOL([OCAMLDOC], [ocamldoc.opt], [])
+AS_IF([test "x$OCAMLDOC" = "x"],
+  [AC_CHECK_TOOL([OCAMLDOC], [ocamldoc], [])])
+AC_CHECK_TOOL([OCAMLDEP], [ocamldep.opt], [])
+AS_IF([test "x$OCAMLDEP" = "x"],
+  [AC_CHECK_TOOL([OCAMLDEP], [ocamldep], [])])
+AC_CHECK_TOOL([OCAMLMKLIB], [ocamlmklib.opt], [])
+AS_IF([test "x$OCAMLMKLIB" = "x"],
+  [AC_CHECK_TOOL([OCAMLMKLIB], [ocamlmklib], [])])
 AC_CHECK_TOOL([OCAMLFIND], [ocamlfind], [])
 AS_IF([test "x$OCAMLFIND" = "x"],
-  [AC_CHECK_TOOL([OCAMLOPT], [ocamlopt.opt], [])
-   AS_IF([test "x$OCAMLOPT" = "x"],
-     [AC_CHECK_TOOL([OCAMLOPT], [ocamlopt], [])])
-   AC_CHECK_TOOL([OCAMLDOC], [ocamldoc.opt], [])
-   AS_IF([test "x$OCAMLDOC" = "x"],
-     [AC_CHECK_TOOL([OCAMLDOC], [ocamldoc], [])])
-   AC_CHECK_TOOL([OCAMLDEP], [ocamldep.opt], [])
-   AS_IF([test "x$OCAMLDEP" = "x"],
-     [AC_CHECK_TOOL([OCAMLDEP], [ocamldep], [])])
-   AC_CHECK_TOOL([OCAMLMKLIB], [ocamlmklib.opt], [])
-   AS_IF([test "x$OCAMLMKLIB" = "x"],
-     [AC_CHECK_TOOL([OCAMLMKLIB], [ocamlmklib], [])])
-   AC_SUBST([RESULT_PKG], [])
+  [AC_SUBST([RESULT_PKG], [])
    AC_SUBST([SEQ_PKG], [])
    AC_SUBST([UCHAR_PKG], [])],
-  [AC_SUBST([OCAMLC], [["$OCAMLFIND ocamlc"]])
-   AC_SUBST([OCAMLOPT], [["$OCAMLFIND ocamlopt"]])
-   AC_SUBST([OCAMLDOC], [["$OCAMLFIND ocamldoc"]])
-   AC_SUBST([OCAMLDEP], [["$OCAMLFIND ocamldep"]])
-   AC_SUBST([OCAMLMKLIB], [["$OCAMLFIND ocamlmklib"]])
-   AC_OCAMLFIND_PKG([RESULT_PKG], [result], [Result])
+  [AC_OCAMLFIND_PKG([RESULT_PKG], [result], [Result])
    AC_OCAMLFIND_PKG([SEQ_PKG], [seq], [Seq])
    AC_OCAMLFIND_PKG([UCHAR_PKG], [uchar], [Uchar])])
 


### PR DESCRIPTION
The Fedora Linux project is preparing to rebuild all of its OCaml packages with OCaml 5.0.0.  This means that, for the first time in some years, we have bytecode-only architectures (ppc64le, for example).  The configure run fails on such architectures if ocamlfind is installed.  Line 81 of configure.ac does this:
```
AC_SUBST([OCAMLC], [["$OCAMLFIND ocamlc"]])
```
But running `ocamlfind ocamlc` prints nothing, at least with ocamlfind 1.9.6 and OCaml 5.0.0.  The same goes for ocamlopt, ocamldoc, ocamldep, and ocamlmklib.  This commit uses `AC_CHECK_TOOL` to find all of them, and ocamlfind is used only to look for the result, seq, and uchar modules.  Note that `OCAMLC` is already set further up in configure.ac.