### PR TITLE
Remove the README symlink to README.md

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-README.md


### PR DESCRIPTION
Automake performs some checks to make sure code complies with the
GNU coding standards. Before Automake 16.4, these chekcs required
a README file to be present, hence the symlink.

Since Automake 16.4 though, the presence of a README.md file is enough
to comply.

As Automake got released in 2021, and since Automake is no longer a
build dependency anyway, we can simply get rid of this symlink.

Closes #27