### PR TITLE
Expose the domain module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ _build/
 /config.log
 /config.status
 /config.sub
+/stamp-h1
 /config.h
 *.so
 /stdcompat__stubs.c

--- a/stdcompat__stdlib.ml.in
+++ b/stdcompat__stdlib.ml.in
@@ -56,6 +56,8 @@ module Complex = Complex
 
 module Digest = Stdcompat__digest
 
+module Domain = Stdcompat__domain
+
 module Either = Stdcompat__either
 
 module Ephemeron = Stdcompat__ephemeron

--- a/stdcompat__stdlib_s.mli.in
+++ b/stdcompat__stdlib_s.mli.in
@@ -57,6 +57,8 @@ module type S = sig
 
   module Digest : Stdcompat__digest_s.S
 
+  module Domain : Stdcompat__domain_s.S
+
   module Either : Stdcompat__either_s.S
 
   module Ephemeron : Stdcompat__ephemeron_s.S


### PR DESCRIPTION
When compiling with a compiler older than OCaml 5.0, stdcompat's
implementation of the domain module was not exposed.