### PR TITLE
Build stdcompat.cmxs only if both native and shared lib support are available

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -101,11 +101,11 @@ endif
 if OCAML_SUPPORTS_NATIVE
 mypkg_SCRIPTS += stdcompat.cmxa stdcompat$(LIBEXT) $(MODULES_native:.ml=.cmx)
 BEST_SUFFIX := .cmx
-endif
-
 if OCAML_SUPPORTS_SHARED
 mypkg_SCRIPTS += stdcompat.cmxs
 endif
+endif
+
 
 PACKAGES = $(RESULT_PKG) $(SEQ_PKG) $(UCHAR_PKG)
 OCAMLFLAGS = $(PACKAGES:%=-package %)

--- a/Makefile.in
+++ b/Makefile.in
@@ -90,7 +90,7 @@ PRE_UNINSTALL = :
 POST_UNINSTALL = :
 @OCAML_SUPPORTS_BYTECODE_TRUE@am__append_1 = stdcompat.cma
 @OCAML_SUPPORTS_NATIVE_TRUE@am__append_2 = stdcompat.cmxa stdcompat$(LIBEXT) $(MODULES_native:.ml=.cmx)
-@OCAML_SUPPORTS_SHARED_TRUE@am__append_3 = stdcompat.cmxs
+@OCAML_SUPPORTS_NATIVE_TRUE@@OCAML_SUPPORTS_SHARED_TRUE@am__append_3 = stdcompat.cmxs
 @OCAML_SUPPORTS_BIN_ANNOT_TRUE@am__append_4 = -bin-annot
 @OCAML_SUPPORTS_BIN_ANNOT_TRUE@am__append_5 = $(MODULES_native:.ml=.cmt)
 @OCAML_SUPPORTS_NO_ALIAS_DEPS_TRUE@am__append_6 = -no-alias-deps
@@ -414,7 +414,7 @@ am__DIST_COMMON = $(srcdir)/META.in $(srcdir)/Makefile.in \
 	$(srcdir)/stdcompat__weak.mli.in \
 	$(srcdir)/stdcompat__weak_s.mli.in \
 	$(srcdir)/stdcompat_tests.ml.in AUTHORS COPYING INSTALL NEWS \
-	README compile install-sh missing
+	README.md compile install-sh missing
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 distdir = $(PACKAGE)-$(VERSION)
 top_distdir = $(distdir)


### PR DESCRIPTION
Before this PR, the only thing that was checked to determine
whether to build stdcompat.cmxs was that shared libraries were
supported. This is indeed necessary but not sufficient: it must
also be checked that the native compiler is available.