### PR TITLE
configure: print the best OCaml compiler

### DIFF
--- a/configure
+++ b/configure
@@ -4886,6 +4886,9 @@ else case e in #(
 esac
 fi
 
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: the best OCaml compiler is $OCAMLBEST" >&5
+printf "%s\n" "$as_me: the best OCaml compiler is $OCAMLBEST" >&6;}
+
 if test "x$OCAMLDEP" = "x"
 then :
   as_fn_error $? "No ocamldep available" "$LINENO" 5

--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,8 @@ AS_IF([test "x$OCAMLOPT" = "x"],
   [AC_SUBST([OCAMLBEST], [["$OCAMLOPT"]])
    AC_SUBST([CMAX], [["cmxa"]])])
 
+AC_MSG_NOTICE([the best OCaml compiler is $OCAMLBEST])
+
 AS_IF([test "x$OCAMLDEP" = "x"],
   [AC_MSG_ERROR([[No ocamldep available]])])
 


### PR DESCRIPTION
This has turned out to be useful for debugging so why not keep it.