### PR TITLE
Stop ignoring stdcompat.ml_{native,byte}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@ _build/
 /tests.bytecode
 /tests.native
 /META
-/stdcompat.ml_byte
-/stdcompat.ml_native
 /.depend
 /stdcompat_*.ml
 /stdcompat_*.mli


### PR DESCRIPTION
This is a follow-up to commit 6976012113e650de58da95a1f57d74004ba40472
(PR #45). However, the patterns in .gitignore were wrong anyway so
they get removed here merely to avoid confusions in the future.