### PR TITLE
Be more liberal with `Sys.ocaml_version`

### DIFF
--- a/tools/compiler_version.ml
+++ b/tools/compiler_version.ml
@@ -137,11 +137,15 @@ let known_versions =
 
 let is_known v = List.mem v known_versions
 
+let is_known_release {major; minor; _} =
+  List.exists (fun { major = major'; minor = minor'; _ } ->
+    major = major' && minor = minor') known_versions
+
 let is_development _ = false
 
 let make x y z extra_info =
   let v = mk x y z in
-  if is_known v then { v with extra_info } else raise Not_found
+  { v with extra_info }
 
 let to_string { major; minor; patch_level; extra_info } =
   let printer = Printf.sprintf in

--- a/tools/compiler_version.mli
+++ b/tools/compiler_version.mli
@@ -56,6 +56,8 @@ val known_versions : t list
 
 val is_known : t -> bool
 
+val is_known_release : t -> bool
+
 val is_development : t -> bool
 
 val major : t -> int


### PR DESCRIPTION
The Dune changes in #54 require a new release of stdcompat for any point releases of OCaml (for example 5.3.1). While 4.07.1 required a minor update, this is very much the exception rather than the rule, and it seems better that the version detection be more liberal. There's also a window on trunk OCaml before anything new is added where the package is still usable.

This change proposes being as liberal as `configure.ac` - `--compiler-version` still requires a recognised OCaml version, though.