### PR TITLE
Expose the Dynarray module

### DIFF
--- a/stdcompat__stdlib_s.mli.in
+++ b/stdcompat__stdlib_s.mli.in
@@ -59,6 +59,8 @@ module type S = sig
 
   module Domain : Stdcompat__domain_s.S
 
+  module Dynarray : Stdcompat__dynarray_s.S
+
   module Either : Stdcompat__either_s.S
 
   module Ephemeron : Stdcompat__ephemeron_s.S


### PR DESCRIPTION
I wasn't able to access the Dynarray module (stdcompat 0.21, OCaml 4.14) and I believe the reason is simply that it is not exposed, so here is a one-line patch. I hope I got this right.