### PR TITLE
Remove `labeled` and `unlabeled` types from CI workflow

### DIFF
--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - 'main'
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
 
 jobs:
   build-ubuntu:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - 'main'
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
 
 jobs:
   build-ubuntu:


### PR DESCRIPTION
This commit removes the `labeled` and `unlabeled` types from CI workflow, since the job is not affected by PR labels, as noticed by Seb Hinderer:
https://github.com/ocamllibs/metapp/pull/14#issuecomment-5263694522